### PR TITLE
fix: pin PSGallery modules to specific versions

### DIFF
--- a/action.ps1
+++ b/action.ps1
@@ -32,7 +32,7 @@ if (Get-Module -ListAvailable -Name GitHubActions -ErrorAction SilentlyContinue)
 else {
     #directly to output here before module loaded to support Write-ActionInfo
     Write-Output "GitHubActions module is not installed.  Installing from Gallery..."
-    Install-Module -Name GitHubActions
+    Install-Module -Name GitHubActions -RequiredVersion '1.1.0.2'
 }
 
 #check if PowerShellForGitHub module is installed
@@ -41,7 +41,7 @@ if (Get-Module -ListAvailable -Name PowerShellForGitHub -ErrorAction SilentlyCon
 }
 else {
     Write-ActionInfo "PowerShellForGitHub module is not installed.  Installing from Gallery..."
-    Install-Module -Name PowerShellForGitHub
+    Install-Module -Name PowerShellForGitHub -RequiredVersion '0.17.0'
 
     #Disable Telemetry since we are accessing sensitive apis - https://github.com/microsoft/PowerShellForGitHub/blob/master/USAGE.md#telemetry
     Set-GitHubConfiguration -DisableTelemetry -SessionOnly


### PR DESCRIPTION
Pin GitHubActions to 1.1.0.2 and PowerShellForGitHub to 0.17.0 via -RequiredVersion to prevent supply chain attacks via compromised PSGallery packages. Same fix applied to secret-scanning-review-action.