### PR TITLE
feat: enable update-readme-sha and add SHA-pinned example

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       version: ${{ inputs.version }}
       bump: ${{ inputs.bump }}
       prerelease: ${{ inputs.prerelease }}
+      update-readme-sha: true
     permissions:
       contents: write
       pull-requests: write

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'KEV Policy'
-        uses: advanced-security/dependabot-kev-action@v0
+        uses: advanced-security/dependabot-kev-action@v0                                          # floating major tag
+        # uses: advanced-security/dependabot-kev-action@13ad89ad9e1b1456550ebabe3e232bea84feb78b # v0.1.0 (pinned)
         env:
             GITHUB_TOKEN: ${{ secrets.DEPENDABOT_KEV_GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
- Adds `update-readme-sha: true` to the release workflow call
- Adds a commented SHA-pinned usage example in README (pointing to v0.1.0)
- Future non-prerelease releases will auto-open a PR to update the SHA pin