### PR TITLE
chore: add dependabot version updates and dependency submission

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+    groups:
+      all-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,16 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0' # Weekly on Sundays
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    uses: advanced-security/reusable-workflows/.github/workflows/dependency-submission.yml@1bbf2c8029a9cfcc587742110e9e8a24eb34c0e0 # main
+    secrets: inherit


### PR DESCRIPTION
- **dependabot.yml**: Weekly grouped updates for github-actions ecosystem with 3-day cooldown
- **dependency-submission.yml**: Reusable workflow for Actions dependency graph submission (runs on push, PR, and weekly)