### PR TITLE
chore: pin reusable workflows to v0.3.3 release tag

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -12,5 +12,5 @@ permissions:
 
 jobs:
   dependency-submission:
-    uses: advanced-security/reusable-workflows/.github/workflows/dependency-submission.yml@1bbf2c8029a9cfcc587742110e9e8a24eb34c0e0 # main
+    uses: advanced-security/reusable-workflows/.github/workflows/dependency-submission.yml@fc65a0660ae8b17a741ce9e172031070574e277d # v0.3.3
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   release:
-    uses: advanced-security/reusable-workflows/.github/workflows/release.yml@1bbf2c8029a9cfcc587742110e9e8a24eb34c0e0 # main
+    uses: advanced-security/reusable-workflows/.github/workflows/release.yml@fc65a0660ae8b17a741ce9e172031070574e277d # v0.3.3
     with:
       version: ${{ inputs.version }}
       bump: ${{ inputs.bump }}


### PR DESCRIPTION
Update SHA pins from branch commit to release tag so Dependabot can detect and propose updates for newer releases.

Before: pinned to arbitrary main commit with \# main\ comment - Dependabot can't determine what's newer.
After: pinned to v0.3.3 release commit with \# v0.3.3\ comment - Dependabot follows semver releases.